### PR TITLE
Fix reset to start new games with player O

### DIFF
--- a/model.py
+++ b/model.py
@@ -38,4 +38,8 @@ class TicTacToeModel:
     def reset(self):
         """Réinitialise la grille pour une nouvelle partie"""
         self.grid = [[0 for _ in range(self.n)] for _ in range(self.n)]
+        # After each game the next one should start with player O
+        # otherwise the player who finished last would start
+        # which is not the expected behaviour.
+        self.current_player = 1
         self.moves = 0


### PR DESCRIPTION
## Summary
- reset current_player to O when starting a new game

## Testing
- `python -m py_compile model.py controller.py view.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688901815524832ba91e86413dd3a32f